### PR TITLE
Fix for leaking zstd buffer

### DIFF
--- a/lib/ior-zstd.c
+++ b/lib/ior-zstd.c
@@ -130,6 +130,7 @@ static void zstd_close(io_t *io)
 {
     ZSTD_freeDStream(DATA(io)->stream);
     wandio_destroy(DATA(io)->parent);
+    free(io->data);
     free(io);
 }
 


### PR DESCRIPTION
data gets malloced in zstd_open, but is never freed.